### PR TITLE
Generate new chapters and second book from doc

### DIFF
--- a/book/second-book-chapter-examples.md
+++ b/book/second-book-chapter-examples.md
@@ -1,0 +1,123 @@
+## Chapter Examples for “Worlds Within: A Field Guide to the Unknown”
+
+These are illustrative, not prescriptive. Use them to spark tests and conversations.
+
+### 1) Epistemic Humility
+- Weather forecast: Carry an umbrella when rain chance is 30%—don’t argue about certainty.
+- Confidence intervals: Speak in ranges, not points.
+- Premortem: Assume failure and list causes before you act.
+
+### 2) Model‑Dependent Realism
+- Map apps: Satellite view vs. transit map—each reveals different truths.
+- Camera lenses: Wide vs. telephoto change the story without changing the scene.
+- Multiple models: Compare Newton, Einstein, and numerical sims for orbits.
+
+### 3) The Map Is Not the Territory
+- Restaurant reviews: Numbers capture some, not all, of the meal.
+- Topographic vs. road maps: Elevation vs. drive time trade‑offs.
+- Checklists + narratives: Blend discrete and continuous descriptions.
+
+### 4) Bayesian Reasoning in the Wild
+- Medical tests: Low base rates make false positives common.
+- Email spam filters: Priors update with each click.
+- Daily bets: Use odds language (“3 to 1”) to curb overconfidence.
+
+### 5) Gödel, Turing, and Incompleteness for Humans
+- Sudoku generators: Some puzzles require backtracking; set time caps.
+- Software halting: Timeouts protect systems from infinite loops.
+- Decision trees: Create “stop rules” when signals don’t converge.
+
+### 6) Predictive Brains and Controlled Hallucination
+- Optical illusions: Priors fill in missing contours (Kanizsa triangle).
+- Noise‑cancelling headphones: Model predicts and subtracts sound.
+- Priors hygiene: Change context to shift expectations.
+
+### 7) Attention as Resource Allocation
+- Single‑threading: One tab at a time for deep work.
+- Pomodoro: Budget focus and rest cycles.
+- Interrupt shields: Batch notifications into windows.
+
+### 8) Memory as Compression
+- Spaced repetition: Flashcards over cramming.
+- Elaborative encoding: Explain to someone else to compress.
+- Reconsolidation: Edit a belief while recalling it.
+
+### 9) Imagination and Simulation
+- Pre‑mortem rehearsal: Walk through failure states.
+- Red team: Invite a skeptic to attack your plan.
+- Monte Carlo: Randomize inputs to see outcome spread.
+
+### 10) Language Shapes Perception
+- Color terms: Languages with extra blues see finer distinctions.
+- Frames: “90% survival” vs. “10% mortality.”
+- New words, new moves: Naming a tactic makes it repeatable.
+
+### 11) The Extended Self
+- Microbiome swap: Diet changes mood via gut‑brain signaling.
+- Tool extension: A phone as working memory.
+- Cultural prosthetics: Norms shape choices by default.
+
+### 12) Quantum Biology in Practice
+- Spin‑based sensors: Inspired by bird compasses.
+- Enzyme design: Tune tunneling rates for better catalysis.
+- Light harvesting: Mimic coherence for solar efficiency.
+
+### 13) Symbiosis and Holobionts
+- Lichen teams: Fungi + algae outperform alone.
+- Organelle origin: Mitochondria as ancient partners.
+- Org design: Pair complementary skills like species.
+
+### 14) Learning at the Edge
+- Add noise: Slight randomness to escape local optima.
+- Temperature schedules: Simulated annealing for creative search.
+- Critical networks: Keep systems flexible but bounded.
+
+### 15) Time’s Arrow and Reversibility
+- Ice‑cube rule: Some processes are practically one‑way.
+- Undo buffers: Build reversibility into workflows.
+- Energy budgets: Track costs of order.
+
+### 16) Black Holes, Holography, and Information
+- Ledger at the boundary: Surface area as accounting.
+- Lossless vs. lossy: What can and can’t be recovered.
+- Backups: Keep metadata—it’s often enough.
+
+### 17) Emergent Spacetime and Networks
+- Social graphs: Shortcuts (hubs) change distances.
+- Fabric analogy: Tight weaves resist tears.
+- Connectivity first: Design teams by interaction patterns.
+
+### 18) Multiverse and Typicality
+- Survivorship bias: Only successful startups get blog posts.
+- Reference classes: Choose the right comparison group.
+- Outside view: Base rates before inside details.
+
+### 19) High Strangeness with High Standards
+- Blinded trials: Hide conditions from subjects and experimenters.
+- Pre‑registration: Specify analyses before seeing data.
+- Adversarial collaboration: Opponents co‑design the test.
+
+### 20) Decisions When You Can’t Be Sure
+- Option value: Keep choices open longer.
+- Min‑max regret: Plan to avoid worst‑case feelings.
+- Barbell strategy: Mix safe core with risky bets.
+
+### 21) Collective Intelligence by Design
+- Two‑pizza teams: Small groups, fast loops.
+- Ritualized dissent: A “red team” seat in every meeting.
+- Write first, talk later: Reduce anchoring.
+
+### 22) Data Hygiene and Info Diets
+- Source calendars: Track freshness of facts.
+- Noise audit: Remove feeds that rarely yield action.
+- Calibration games: Score your confidence.
+
+### 23) Everyday Experiments
+- A/B habits: Alternate weeks, track outcomes.
+- N‑of‑1 dashboards: Sleep, mood, focus correlations.
+- Small stakes: Keep trials reversible.
+
+### 24) Ethics for the Unknown Unknowns
+- Precautionary principle: Slow down when stakes are opaque.
+- Rights of uncertain minds: Treat possible sentience with care.
+- Sunset clauses: Re‑evaluate when conditions change.

--- a/book/second-book-outline.md
+++ b/book/second-book-outline.md
@@ -1,0 +1,62 @@
+## Book Thesis — Worlds Within: A Field Guide to the Unknown
+
+- This second book is a practical and philosophical companion: how to think, decide, and live amid radical uncertainty. It translates frontier ideas into methods for inquiry, collaboration, and meaning‑making without overclaiming.
+- The throughline: epistemic humility + disciplined curiosity + collective intelligence.
+
+### Super‑Chapter I: Limits of Knowing (Epistemology for Everyday Life)
+1) Epistemic Humility
+- Plan: Distinguish between ignorance, risk, and deep uncertainty; adopt provisional beliefs.
+2) Model‑Dependent Realism
+- Plan: Treat theories as lenses; compare predictions across models, not metaphysical labels.
+3) The Map Is Not the Territory
+- Plan: Use multiple representations; triangulate via measurement, narrative, and simulation.
+4) Bayesian Reasoning in the Wild
+- Plan: Update beliefs with likelihoods and priors; avoid certainty language.
+5) Gödel, Turing, and Incompleteness for Humans
+- Plan: Embrace limits; design stop rules and escalation paths when answers don’t exist.
+
+### Super‑Chapter II: Minds as Model Builders (Cognition as Computation)
+6) Predictive Brains and Controlled Hallucination
+- Plan: Perception as inference; manage priors via attention, context, and uncertainty estimates.
+7) Attention as Resource Allocation
+- Plan: Treat attention as a budget; apply “single‑threading” for complex tasks.
+8) Memory as Compression
+- Plan: Use spaced repetition, generative recall, and reconsolidation windows.
+9) Imagination and Simulation
+- Plan: Mental models for scenario planning; red‑team your own beliefs.
+10) Language Shapes Perception
+- Plan: Naming as constraint; use diverse vocabularies to widen perception.
+
+### Super‑Chapter III: Life as Information Flow (Biology Reframed)
+11) The Extended Self: Microbiome, Tools, and Culture
+- Plan: Expand identity beyond skin; track how external systems change cognition.
+12) Quantum Biology in Practice
+- Plan: What magnetoreception, tunneling, and coherence might mean for sensors and medicine.
+13) Symbiosis and Holobionts
+- Plan: Cooperation as computation; design teams like ecosystems.
+14) Learning at the Edge: Criticality and Noise
+- Plan: Harness variability and stochastic resonance for creativity.
+
+### Super‑Chapter IV: A Cosmos of Puzzles (Physics Without Finality)
+15) Time’s Arrow and Reversibility
+- Plan: Separate thermodynamic, psychological, and cosmological arrows; design around asymmetries.
+16) Black Holes, Holography, and Information
+- Plan: Use conservation constraints as thinking tools; reason about what must be true.
+17) Emergent Spacetime and Networks
+- Plan: Model connectivity and flow; explore graph thinking for real systems.
+18) Multiverse, Anthropic Filters, and Typicality
+- Plan: Avoid selection bias; reason under observer effects.
+19) High Strangeness with High Standards
+- Plan: UAPs, psi, and anomalies as adversarial testing grounds; insist on blinded, pre‑registered protocols.
+
+### Super‑Chapter V: Practice Under Uncertainty (Designing Life and Work)
+20) Decisions When You Can’t Be Sure
+- Plan: Robust satisficing, regret minimization, and option value.
+21) Collective Intelligence by Design
+- Plan: Small‑group protocols, dissent norms, and rapid feedback loops.
+22) Data Hygiene and Info Diets
+- Plan: Calibrate sources; measure signal‑to‑noise and novelty.
+23) Everyday Experiments
+- Plan: N‑of‑1 trials, A/B habits, and personal dashboards.
+24) Ethics for the Unknown Unknowns
+- Plan: Reversibility, harm bounds, and rights for possible minds.

--- a/book/thirty-new-chapters.md
+++ b/book/thirty-new-chapters.md
@@ -1,0 +1,183 @@
+## 30 New Chapters: Mind‑Blowing Unknowns at the Edge of Science and Philosophy
+
+These chapters extend the existing themes with fresh frontiers. Each includes accessible examples that suggest testable questions while acknowledging uncertainty.
+
+### 1) The Hard Problem of Consciousness
+- Mirror test: Self-recognition appears in some animals, but subjective feel (qualia) remains unexplained.
+- Pain vs. nociception: Reflexes can occur without the felt experience of pain.
+- Color in a blind brain: People born blind can reason about color without seeing it.
+- Mary’s room: Knowing all the physics may not capture “what it’s like.”
+
+### 2) The Binding Problem
+- Cinema of mind: Features (color, shape, motion) are processed separately yet appear unified.
+- Cocktail party: You can track one voice across multiple speakers.
+- Split attention: Multitasking shows seams in the binding when pushed.
+- Illusory conjunctions: Under load, features swap (red square ↔ blue circle).
+
+### 3) Inverted Spectrum and Qualia Twins
+- Private color: Two people agree on “green,” yet internal feels could differ.
+- Sensor swap: A camera sees the same; the experience could still flip.
+- Language stability: Shared words hide subjective variance.
+- Neural correlate ≠ identity: Correlation without a clear bridge.
+
+### 4) Split‑Brain: Two Minds in One Head
+- Separate cursors: Each hand can act semi‑independently after callosotomy.
+- Confabulation: One hemisphere invents reasons for choices it didn’t make.
+- Hidden knowledge: Information crosses via subtle cues.
+- Unity as construct: “One self” may be a negotiated treaty.
+
+### 5) Predictive Processing: Controlled Hallucination
+- Hollow‑face mask: Prior beliefs flip 3D perception.
+- Tinnitus/phantom phone: Brain fills in expected signals.
+- VR sickness: Model mismatch yields nausea.
+- Placebo vision: Expectation sharpens ambiguous input.
+
+### 6) Free Will in a Determined Brain
+- Readiness potentials: Brain activity precedes reported choice.
+- Veto window: Late cancellation suggests layered control.
+- Framing effects: Context biases “decisions.”
+- Compatibilism: Freedom as skillful control, not randomness.
+
+### 7) Quantum Biology: Life’s Subtle Tricks
+- Enzyme tunneling: Reactions sped by quantum leaps.
+- Avian compass: Magnetoreception via spin chemistry.
+- Photosynthesis coherence: Energy walks efficiently.
+- Olfaction by vibration: Smell as molecular spectra.
+
+### 8) Senses Beyond Ours: Magnetism, Electric Fields, and More
+- Sharks’ electroreception: Detecting heartbeats in murky water.
+- Migratory birds: Following Earth’s field lines.
+- Platypus bill: Electric pulses map prey.
+- Infrasound: Elephants talk below our hearing.
+
+### 9) Cognitive Maps: Grid Cells and Place Cells
+- Taxi brains: Hippocampi enlarge with spatial expertise.
+- Virtual worlds: Cells remap in simulations.
+- Concept spaces: Abstract knowledge shows “places.”
+- Navigation errors: Stress distorts mental maps.
+
+### 10) Memory Is Editing: Reconsolidation and False Memory
+- Story drift: Retelling alters details.
+- Misinformation effect: Leading questions plant elements.
+- Reconsolidation window: Updating during recall.
+- Flashbulb fallibility: Vivid ≠ accurate.
+
+### 11) Déjà Vu and Temporal Glitches
+- Double take: Processing delays create familiarity.
+- Scene echoes: Similar layouts trigger “already seen.”
+- Temporal lobe sparks: Stimulation induces déjà vu.
+- Predictive reuse: Brain recycles templates to save effort.
+
+### 12) Dreams as Data Augmentation
+- REM rehearsal: Threat simulation for safer waking.
+- Creative recombination: Novel links appear in sleep.
+- Memory integration: New info weaves into old.
+- Lucid control: Metacognition can steer scenarios.
+
+### 13) Psychedelics and the Self Model
+- DMN quieting: Ego boundaries relax when control hubs go offline.
+- Entropic brain: Increased variability correlates with openness.
+- Therapeutic window: Context and integration matter.
+- Persisting change: Traits shift beyond acute effects.
+
+### 14) Near‑Death Experience: Edges of Consciousness
+- Tunnel/light: Common motifs across cultures.
+- Anesthesia awareness: Consciousness can flicker under deep sedation.
+- Hypoxia signatures: Physiology mimics mystical elements.
+- Veridical claims: Design blinded tests to probe reports.
+
+### 15) Blindsight and Unconscious Seeing
+- Guessing right: Accurate choices without visual awareness.
+- Dual pathways: Action guidance bypasses conscious vision.
+- Masking: Stimuli influence behavior unseen.
+- Attention without awareness: Covert shifts steer perception.
+
+### 16) Stochastic Resonance: When Noise Helps
+- Whispering gallery: A little noise boosts weak signals.
+- Sensory thresholds: Vibration improves fingertip sensitivity.
+- Decision dithering: Variability prevents ruts.
+- Evolutionary exploration: Noise seeds innovation.
+
+### 17) Criticality: Brains at the Edge of Chaos
+- Forest fires: Power‑law cascades echo neural avalanches.
+- Balanced networks: Flexible yet stable computation.
+- Phase transitions: Small nudges, large effects.
+- Optimal trade‑off: Sensitivity vs. robustness sweet spot.
+
+### 18) Gödel, Turing, and the Limits of Knowing
+- True but unprovable: Formal systems have blind spots.
+- Halting problem: Some outcomes can’t be predicted in advance.
+- Map ≠ territory: Models always omit reality.
+- Science as iteration: Progress without final closure.
+
+### 19) The Arrow of Time and the Mind
+- Memory asymmetry: We remember past, not future.
+- Entropy of narratives: Stories compress disorder.
+- Mental thermodynamics: Effort tracks energy budgets.
+- Reversible micro, irreversible macro: Life navigates the gap.
+
+### 20) Retrocausality and Time‑Symmetric Physics
+- Two‑time boundary: Outcomes constrain histories.
+- Delayed choice: Measurements seem to rewrite past options.
+- Bayesian update: Future data reshapes present beliefs.
+- Causation as inference: Arrows may be perspectival.
+
+### 21) The Quantum Measurement Problem
+- Collapse vs. branching: Competing pictures of outcomes.
+- Wigner’s friend: Observers disagree on facts.
+- Contextuality: Values depend on the measurement set.
+- Macroscopic cut: Where does quantum become classical?
+
+### 22) Black Holes and the Information Paradox
+- No‑hair puzzle: Few numbers describe rich matter.
+- Hawking radiation: Evaporation threatens information.
+- Firewalls vs. smoothness: Incompatible principles collide.
+- Holographic bookkeeping: Information at the horizon.
+
+### 23) Emergent Spacetime from Entanglement
+- Tapestry model: Geometry as woven correlations.
+- Wormholes = entanglement?: ER=EPR conjecture.
+- Entropy areas: Surfaces count information.
+- Connectivity as gravity: Curvature from network structure.
+
+### 24) Quantum Gravity: Strings, Loops, and Beyond
+- Vibrating strings: Particles as modes.
+- Spin networks: Space quantized into chunks.
+- Asymptotic safety: Gravity tamed at high energy.
+- Experimental gaps: Indirect clues over direct tests.
+
+### 25) Origin of Life: From Chemistry to Code
+- Metabolism first vs. replication first: Competing starts.
+- Hydrothermal vents: Natural reactors.
+- Lipid worlds: Self‑assembling compartments.
+- Chemical evolution: Selection before genes.
+
+### 26) Alien Life as We Don’t Know It
+- Silicon or solvent swaps: Alternative biochemistries.
+- Shadow biospheres: Missed life with odd signatures.
+- Technosignatures: Waste heat, beacons, artifacts.
+- Time windows: Civilizations may be brief and rare.
+
+### 27) Anthropic Reasoning and Selection Effects
+- Lottery fallacy: Surprised observer in a filtered sample.
+- Survivorship bias: Success stories dominate memory.
+- Measure problem: Counting observers is hard.
+- Copernican caution: Typicality assumptions matter.
+
+### 28) Boltzmann Brains and Cosmic Puzzles
+- Random minds: Fluctuations could outnumber evolved observers.
+- Paradox: If typical, our memories are suspect.
+- Model pressure: Theories must avoid absurd dominance.
+- Arrow constraints: Low‑entropy pasts still needed.
+
+### 29) AI Minds: Can Machines Have Qualia?
+- Chinese room: Syntax vs. understanding.
+- Functional equivalence: If behavior matches, does experience?
+- Report vs. reality: Deception or emergence?
+- Ethical precaution: Suffering risk under uncertainty.
+
+### 30) Ghosts and the Unseen: Signal, Noise, and Meaning
+- Infrasound and EM fields: Environmental causes of “hauntings.”
+- Pareidolia: Seeing faces in noise.
+- Place memory: Buildings as narrative amplifiers.
+- Blind testing: Control conditions separate story from signal.


### PR DESCRIPTION
Adds 30 new chapters and a second book outline with examples to expand on mind-blowing facts.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ee92f92-06aa-4c5d-9b7d-949fadcef788">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ee92f92-06aa-4c5d-9b7d-949fadcef788">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

